### PR TITLE
Add training and persistence capabilities for NER

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ Get all tags for a model
 model.tags
 ```
 
+### Training a Named Entity Extractor
+
+Load a MITIE NER model into a trainer
+
+```ruby
+trainer = Mitie::NERTrainer.new("total_word_feature_extractor.dat")
+```
+
+Create training instances to train against
+
+```ruby
+sample = Mitie::NERTrainingInstance.new(["My", "name", "is", "Hoots", "Owl", "and", "I", "work", "for", "Birdland", "."])
+sample.add_entity(3...5, "person") # Hoots Owl
+sample.add_entity(9...10, "org") # Birdland
+```
+
+Add the training instances to the trainer
+
+```ruby
+trainer.add(sample)
+```
+
+Train the NER and start using it
+
+```ruby
+ner = trainer.train
+
+ner.entities(["I", "met", "with", "Oscar", "Grouch", "at", "Grouchland", "."])
+```
+
 ## Binary Relation Detection
 
 Detect relationships betweens two entities, like:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ ner = trainer.train
 ner.entities(["I", "met", "with", "Oscar", "Grouch", "at", "Grouchland", "."])
 ```
 
+Save the trained model
+
+```ruby
+ner.save_to_disk("my_model.dat")
+```
+
 ## Binary Relation Detection
 
 Detect relationships betweens two entities, like:

--- a/lib/mitie.rb
+++ b/lib/mitie.rb
@@ -6,6 +6,7 @@ require "mitie/binary_relation_detector"
 require "mitie/document"
 require "mitie/ner"
 require "mitie/ner_training_instance"
+require "mitie/ner_trainer"
 require "mitie/utils"
 require "mitie/version"
 

--- a/lib/mitie.rb
+++ b/lib/mitie.rb
@@ -5,6 +5,7 @@ require "fiddle/import"
 require "mitie/binary_relation_detector"
 require "mitie/document"
 require "mitie/ner"
+require "mitie/utils"
 require "mitie/version"
 
 module Mitie

--- a/lib/mitie.rb
+++ b/lib/mitie.rb
@@ -5,6 +5,7 @@ require "fiddle/import"
 require "mitie/binary_relation_detector"
 require "mitie/document"
 require "mitie/ner"
+require "mitie/ner_training_instance"
 require "mitie/utils"
 require "mitie/version"
 

--- a/lib/mitie/document.rb
+++ b/lib/mitie/document.rb
@@ -84,11 +84,7 @@ module Mitie
     def tokenize
       @tokenize ||= begin
         if text.is_a?(Array)
-          # malloc uses memset to set all bytes to 0
-          tokens_ptr = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP * (text.size + 1))
-          text.size.times do |i|
-            tokens_ptr[i * Fiddle::SIZEOF_VOIDP, Fiddle::SIZEOF_VOIDP] = Fiddle::Pointer.to_ptr(text[i]).ref
-          end
+          tokens_ptr = Utils.array_to_pointer(text)
           [tokens_ptr, nil]
         else
           offsets_ptr = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP)

--- a/lib/mitie/ffi.rb
+++ b/lib/mitie/ffi.rb
@@ -32,6 +32,15 @@ module Mitie
     extern "int mitie_overlaps_any_entity(mitie_ner_training_instance* instance, unsigned long start, unsigned long length)"
     extern "int mitie_add_ner_training_entity(mitie_ner_training_instance* instance, unsigned long start, unsigned long length, const char* label)"
 
+    extern "mitie_ner_trainer* mitie_create_ner_trainer(const char* filename)"
+    extern "unsigned long mitie_ner_trainer_size(const mitie_ner_trainer* trainer)"
+    extern "int mitie_add_ner_training_instance(mitie_ner_trainer* trainer, const mitie_ner_training_instance* instance)"
+    extern "void mitie_ner_trainer_set_beta(mitie_ner_trainer* trainer, double beta)"
+    extern "double mitie_ner_trainer_get_beta(const mitie_ner_trainer* trainer)"
+    extern "void mitie_ner_trainer_set_num_threads(mitie_ner_trainer* trainer, unsigned long num_threads)"
+    extern "unsigned long mitie_ner_trainer_get_num_threads(const mitie_ner_trainer* trainer)"
+    extern "mitie_named_entity_extractor* mitie_train_named_entity_extractor(const mitie_ner_trainer* trainer)"
+
     extern "mitie_binary_relation_detector* mitie_load_binary_relation_detector(const char* filename)"
     extern "const char* mitie_binary_relation_detector_name_string(const mitie_binary_relation_detector* detector)"
     extern "int mitie_entities_overlap(unsigned long arg1_start, unsigned long arg1_length, unsigned long arg2_start, unsigned long arg2_length)"

--- a/lib/mitie/ffi.rb
+++ b/lib/mitie/ffi.rb
@@ -26,6 +26,12 @@ module Mitie
     extern "const char* mitie_ner_get_detection_tagstr(const mitie_named_entity_detections* dets, unsigned long idx)"
     extern "double mitie_ner_get_detection_score(const mitie_named_entity_detections* dets, unsigned long idx)"
 
+    extern "mitie_ner_training_instance* mitie_create_ner_training_instance(char** tokens)"
+    extern "unsigned long mitie_ner_training_instance_num_entities(const mitie_ner_training_instance* instance)"
+    extern "unsigned long mitie_ner_training_instance_num_tokens(const mitie_ner_training_instance* instance)"
+    extern "int mitie_overlaps_any_entity(mitie_ner_training_instance* instance, unsigned long start, unsigned long length)"
+    extern "int mitie_add_ner_training_entity(mitie_ner_training_instance* instance, unsigned long start, unsigned long length, const char* label)"
+
     extern "mitie_binary_relation_detector* mitie_load_binary_relation_detector(const char* filename)"
     extern "const char* mitie_binary_relation_detector_name_string(const mitie_binary_relation_detector* detector)"
     extern "int mitie_entities_overlap(unsigned long arg1_start, unsigned long arg1_length, unsigned long arg2_start, unsigned long arg2_length)"

--- a/lib/mitie/ffi.rb
+++ b/lib/mitie/ffi.rb
@@ -13,6 +13,7 @@ module Mitie
     extern "void mitie_free(void* object)"
     extern "char** mitie_tokenize(const char* text)"
     extern "char** mitie_tokenize_with_offsets(const char* text, unsigned long** token_offsets)"
+    extern "int mitie_save_named_entity_extractor(const char* filename, const mitie_named_entity_extractor* ner)"
 
     extern "mitie_named_entity_extractor* mitie_load_named_entity_extractor(const char* filename)"
     extern "unsigned long mitie_get_num_possible_ner_tags(const mitie_named_entity_extractor* ner)"

--- a/lib/mitie/ner.rb
+++ b/lib/mitie/ner.rb
@@ -2,11 +2,18 @@ module Mitie
   class NER
     attr_reader :pointer
 
-    def initialize(path)
-      # better error message
-      raise ArgumentError, "File does not exist" unless File.exist?(path)
-      @pointer = FFI.mitie_load_named_entity_extractor(path)
-      ObjectSpace.define_finalizer(self, self.class.finalize(pointer))
+    def initialize(path = nil, pointer: nil)
+      if path
+        # better error message
+        raise ArgumentError, "File does not exist" unless File.exist?(path)
+        @pointer = FFI.mitie_load_named_entity_extractor(path)
+      elsif pointer
+        @pointer = pointer
+      else
+        raise ArgumentError, "Must pass either a path or a pointer"
+      end
+
+      ObjectSpace.define_finalizer(self, self.class.finalize(@pointer))
     end
 
     def tags

--- a/lib/mitie/ner.rb
+++ b/lib/mitie/ner.rb
@@ -30,6 +30,13 @@ module Mitie
       doc(text).entities
     end
 
+    def save_to_disk(filename)
+      if FFI.mitie_save_named_entity_extractor(filename, pointer) != 0
+        raise "Unable to save NER to the file #{filename}"
+      end
+      nil
+    end
+
     def tokens(text)
       doc(text).tokens
     end

--- a/lib/mitie/ner_trainer.rb
+++ b/lib/mitie/ner_trainer.rb
@@ -1,0 +1,53 @@
+module Mitie
+  class NERTrainer
+    def initialize(filename)
+      raise ArgumentError, "File `#{filename}' does not exist" unless File.exist?(filename)
+      @pointer = FFI.mitie_create_ner_trainer(filename)
+
+      ObjectSpace.define_finalizer(self, self.class.finalize(@pointer))
+    end
+
+    def add(instance)
+      FFI.mitie_add_ner_training_instance(@pointer, instance.pointer)
+    end
+
+    def beta
+      FFI.mitie_ner_trainer_get_beta(@pointer)
+    end
+
+    def beta=(value)
+      raise ArgumentError, "beta must be greater than or equal to zero" unless value >= 0
+
+      FFI.mitie_ner_trainer_set_beta(@pointer, value)
+      nil
+    end
+
+    def num_threads
+      FFI.mitie_ner_trainer_get_num_threads(@pointer)
+    end
+
+    def num_threads=(value)
+      FFI.mitie_ner_trainer_set_num_threads(@pointer, value)
+      nil
+    end
+
+    def size
+      FFI.mitie_ner_trainer_size(@pointer)
+    end
+
+    def train
+      raise "You can't call train() on an empty trainer" if size.zero?
+
+      extractor = FFI.mitie_train_named_entity_extractor(@pointer)
+
+      raise "Unable to create named entity extractor. Probably ran out of RAM." if extractor.null?
+
+      Mitie::NER.new(pointer: extractor)
+    end
+
+    # :nodoc:
+    def self.finalize(pointer)
+      proc { FFI.mitie_free(pointer) }
+    end
+  end
+end

--- a/lib/mitie/ner_training_instance.rb
+++ b/lib/mitie/ner_training_instance.rb
@@ -1,0 +1,49 @@
+module Mitie
+  class NERTrainingInstance
+    def initialize(tokens)
+      tokens_pointer = Utils.array_to_pointer(tokens)
+
+      @pointer = FFI.mitie_create_ner_training_instance(tokens_pointer)
+      raise "Unable to create ner_training_instance. Probably ran out of RAM." if @pointer.null?
+
+      ObjectSpace.define_finalizer(self, self.class.finalize(@pointer))
+    end
+
+    attr_reader :pointer
+
+    def add_entity(range, label)
+      if range.none? || range.end >= num_tokens || range.begin < 0
+        raise ArgumentError, "Invalid range given to `add_entity'"
+      end
+
+      raise ArgumentError, "oops, it overlaps" if overlaps_any_entity?(range)
+
+      unless FFI.mitie_add_ner_training_entity(@pointer, range.begin, range.size, label).zero?
+        raise "Unable to add entity to training instance. Probably ran out of RAM."
+      end
+
+      nil
+    end
+
+    def num_entities
+      FFI.mitie_ner_training_instance_num_entities(@pointer)
+    end
+
+    def num_tokens
+      FFI.mitie_ner_training_instance_num_tokens(@pointer)
+    end
+
+    def overlaps_any_entity?(range)
+      if range.none? || range.max >= num_tokens
+        raise ArgumentError, "Invalid range given to `overlaps_any_entity?'"
+      end
+
+      FFI.mitie_overlaps_any_entity(@pointer, range.begin, range.size) == 1
+    end
+
+    # :nodoc:
+    def self.finalize(pointer)
+      proc { FFI.mitie_free(pointer) }
+    end
+  end
+end

--- a/lib/mitie/utils.rb
+++ b/lib/mitie/utils.rb
@@ -1,0 +1,14 @@
+module Mitie
+  module Utils
+    def self.array_to_pointer(text)
+      # malloc uses memset to set all bytes to 0
+      tokens_ptr = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP * (text.size + 1))
+
+      text.size.times do |i|
+        tokens_ptr[i * Fiddle::SIZEOF_VOIDP, Fiddle::SIZEOF_VOIDP] = Fiddle::Pointer.to_ptr(text[i]).ref
+      end
+
+      tokens_ptr
+    end
+  end
+end

--- a/test/ner_test.rb
+++ b/test/ner_test.rb
@@ -34,4 +34,15 @@ class NERTest < Minitest::Test
     end
     assert_equal "File does not exist", error.message
   end
+
+  def test_save_to_disk
+    tempfile = Tempfile.new
+
+    model.save_to_disk(tempfile.path)
+
+    assert File.exist?(tempfile.path)
+  ensure
+    tempfile.close
+    tempfile.unlink
+  end
 end

--- a/test/ner_trainer_test.rb
+++ b/test/ner_trainer_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module Mitie
+  class NERTrainerTest < Minitest::Test
+    def test_beta_accessors
+      trainer = Mitie::NERTrainer.new(feature_extractor)
+
+      trainer.beta = 2.0
+
+      assert_equal 2.0, trainer.beta
+    end
+
+    def test_beta_writer_raises_on_invalid_input
+      trainer = Mitie::NERTrainer.new(feature_extractor)
+
+      assert_raises(ArgumentError) { trainer.beta = -0.5 }
+    end
+
+    def test_num_threads_accessors
+      trainer = Mitie::NERTrainer.new(feature_extractor)
+
+      trainer.num_threads = 2
+
+      assert_equal 2, trainer.num_threads
+    end
+
+    def test_train
+      sample = Mitie::NERTrainingInstance.new(["My", "name", "is", "Hoots", "Owl", "and", "I", "work", "for", "Birdland", "."])
+      sample.add_entity(3...5, "person")
+      sample.add_entity(9...10, "org")
+
+      sample2 = Mitie::NERTrainingInstance.new(["The", "other", "day", "at", "work", "I", "saw", "Oscar", "Grouch", "from", "Grouchland", "."])
+      sample2.add_entity(7...9, "person")
+      sample2.add_entity(10...11, "org")
+
+      trainer = Mitie::NERTrainer.new(feature_extractor)
+      trainer.add(sample)
+      trainer.add(sample2)
+      trainer.num_threads = Etc.nprocessors - 1
+
+      ner = silence_stdout { trainer.train }
+
+      assert ner.is_a?(Mitie::NER)
+    end
+
+    def test_train_raises_without_any_training_instances
+      trainer = Mitie::NERTrainer.new(feature_extractor)
+
+      assert_raises(StandardError) { trainer.train }
+    end
+
+    private
+
+    def feature_extractor
+      "#{models_path}/total_word_feature_extractor.dat"
+    end
+  end
+end

--- a/test/ner_training_instance_test.rb
+++ b/test/ner_training_instance_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+module Mitie
+  class NERTrainingInstanceTest < Minitest::Test
+    def test_add_entity_raises_on_invalid_input
+      sample = Mitie::NERTrainingInstance.new(
+        ["I", "raise", "errors", "."]
+      )
+      sample.add_entity((2..2), "noun")
+
+      assert_raises(ArgumentError) { sample.add_entity(1...1, "nope") }
+      assert_raises(ArgumentError) { sample.add_entity(1...9, "nope") }
+      assert_raises(ArgumentError) { sample.add_entity(-1...2, "nope") }
+      assert_raises(ArgumentError) { sample.add_entity(2..2, "nope") }
+    end
+
+    def test_num_entities
+      sample = Mitie::NERTrainingInstance.new(
+        ["My", "name", "is", "Hoots", "Owl", "and", "I", "work", "for", "Birdland", "."]
+      )
+
+      assert_equal 0, sample.num_entities
+
+      sample.add_entity(3...5, "person")
+      sample.add_entity(9...10, "org")
+
+      assert_equal 2, sample.num_entities
+    end
+
+    def test_num_tokens
+      sample = Mitie::NERTrainingInstance.new(
+        ["I", "have", "five", "tokens", "."]
+      )
+
+      assert_equal 5, sample.num_tokens
+    end
+
+    def test_overlaps_any_entity
+      sample = Mitie::NERTrainingInstance.new(
+        ["I", "am", "become", "Death", ",", "destroyer", "of", "worlds", "."]
+      )
+      sample.add_entity(0..0, "person")
+      sample.add_entity(3..3, "phenomenon")
+
+      assert sample.overlaps_any_entity?(1..3)
+      refute sample.overlaps_any_entity?(5..8)
+    end
+
+    def test_overlaps_any_entity_raises_errors
+      sample = Mitie::NERTrainingInstance.new(
+        ["I", "raise", "errors", "."]
+      )
+      sample.add_entity(2..2, "noun")
+
+      assert_raises(ArgumentError) { sample.overlaps_any_entity?(1...1) }
+      assert_raises(ArgumentError) { sample.overlaps_any_entity?(9..12) }
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@ Bundler.require(:default)
 require "minitest/autorun"
 require "minitest/pride"
 
+require "etc"
+
 class Minitest::Test
   # memoize for performance
   def model
@@ -15,5 +17,15 @@ class Minitest::Test
 
   def text
     "Nat works at GitHub in San Francisco"
+  end
+
+  def silence_stdout
+    old_stdout = STDOUT.dup
+    STDOUT.reopen(IO::NULL)
+    STDOUT.sync = true
+    yield
+  ensure
+    STDOUT.reopen(old_stdout)
+    old_stdout.close
   end
 end


### PR DESCRIPTION
Using the pre-generated models for MITIE (or one you generate yourself via another API), you can now train models for Named Entity Recognition using training instances and a trainer.

The API for all of these added methods roughly matches that from the Python library for consistency across languages.